### PR TITLE
feat: add support for loading in predefined alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,11 @@ def run(plan, args={}):
         plan,
         prometheus_url,
         "github.com/example-org/example-package/static-files/dashboards",
-        # optionally load predefined grafana alerts from file
-        grafana_alerts_file="github.com/example-org/example-package/static-files/alerts.yaml",
+        # optionally set the grafana version
+        grafana_version="11.1.0",
+        # optionally load predefined grafana alerting configuration
+        grafana_alerting_template="github.com/example-org/example-package/static-files/alerting.yml.tmpl",
+        grafana_alerting_data={},
     )
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,13 @@ def run(plan, args={}):
     prometheus_url = prometheus-package.run(plan, [service_a_metrics_job])
 
     # start grafana where dashboards are located at github.com/example-org/example-package/static-files/dashboards
-    grafana.run(plan, prometheus_url, "github.com/example-org/example-package/static-files/dashboards")
+    grafana.run(
+        plan,
+        prometheus_url,
+        "github.com/example-org/example-package/static-files/dashboards",
+        # optionally load predefined grafana alerts from file
+        grafana_alerts_file=read_file(src="./static-files/alerts.yaml"),
+    )
 ```
 
 If you want to use a fork or specific version of this package in your own package, you can replace the dependencies in your `kurtosis.yml` file using the [replace](https://docs.kurtosis.com/concepts-reference/kurtosis-yml/#replace) primitive. 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ def run(plan, args={}):
         prometheus_url,
         "github.com/example-org/example-package/static-files/dashboards",
         # optionally load predefined grafana alerts from file
-        grafana_alerts_file=read_file(src="./static-files/alerts.yaml"),
+        grafana_alerts_file="github.com/example-org/example-package/static-files/alerts.yaml",
     )
 ```
 

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,2 +1,3 @@
-name: "github.com/kurtosis-tech/grafana-package"
-
+name: "github.com/minhd-vu/grafana-package"
+replace:
+  github.com/kurtosis-tech/grafana-package: github.com/minhd-vu/grafana-package@alerts

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,3 +1,1 @@
-name: "github.com/minhd-vu/grafana-package"
-replace:
-  github.com/kurtosis-tech/grafana-package: github.com/minhd-vu/grafana-package@alerts
+name: "github.com/kurtosis-tech/grafana-package"

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,2 +1,3 @@
 name: "github.com/kurtosis-tech/grafana-package"
-
+replace:
+  github.com/kurtosis-tech/grafana-package: github.com/minhd-vu/grafana-package@alerts

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,1 +1,2 @@
 name: "github.com/kurtosis-tech/grafana-package"
+

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,3 +1,3 @@
-name: "github.com/kurtosis-tech/grafana-package"
+name: "github.com/minhd-vu/grafana-package"
 replace:
   github.com/kurtosis-tech/grafana-package: github.com/minhd-vu/grafana-package@alerts

--- a/main.star
+++ b/main.star
@@ -13,9 +13,10 @@ def run(
     """Runs provided Grafana dashboards in Kurtosis.
 
     Args:
-        prometheus_url(string): Prometheus endpoint that will populate Grafana dashboard data.
-        grafana_dashboards_location(string): Where to find config for Grafana dashboard(s) (usually sitting somewhere repo of that's importing this package))
-        grafana_dashboards_name(string): Name of Grafana Dashboard provider.
+        prometheus_url (string): Prometheus endpoint that will populate Grafana dashboard data.
+        grafana_dashboards_location (string): Where to find config for Grafana dashboard(s) (usually sitting somewhere in the repo that's importing this package).
+        grafana_dashboards_name (string): Name of Grafana Dashboard provider.
+        grafana_alerts_file (string, optional): Path to the Grafana alerts file (usually sitting somewhere in the repo that's importing this package).
     """
 
     # create config files artifacts based on datasource and dashboard providers info

--- a/main.star
+++ b/main.star
@@ -8,8 +8,8 @@ def run(
     grafana_dashboards_location,
     name="grafana",
     grafana_dashboards_name="Grafana Dashboards in Kurtosis",
-    grafana_alerts_template="",
-    grafana_alerts_data={},
+    grafana_alerting_template="",
+    grafana_alerting_data={},
 ):
     """Runs provided Grafana dashboards in Kurtosis.
 
@@ -17,7 +17,8 @@ def run(
         prometheus_url (string): Prometheus endpoint that will populate Grafana dashboard data.
         grafana_dashboards_location (string): Where to find config for Grafana dashboard(s) (usually sitting somewhere in the repo that's importing this package).
         grafana_dashboards_name (string): Name of Grafana Dashboard provider.
-        grafana_alerts_file (string, optional): Path to the Grafana alerts file (usually sitting somewhere in the repo that's importing this package).
+        grafana_alerting_template (string, optional): Path to the Grafana alerting file (usually sitting somewhere in the repo that's importing this package).
+        grafana_alerting_data (dict[string, string], optional): The data used when templating the grafana_alerting_template.
     """
 
     # create config files artifacts based on datasource and dashboard providers info
@@ -38,9 +39,9 @@ def run(
                     "DashboardsDirpath": DASHBOARDS_DIR_PATH,
                 },
             ),
-            "alerting/alerts.yml": struct(
-                template=read_file(grafana_alerts_template),
-                data=grafana_alerts_data,
+            "alerting/alerting.yml": struct(
+                template=read_file(grafana_alerting_template),
+                data=grafana_alerting_data,
             ),
         }
     )

--- a/main.star
+++ b/main.star
@@ -54,7 +54,7 @@ def run(
     plan.add_service(
         name=name,
         config=ServiceConfig(
-            image="grafana/grafana",
+            image="grafana/grafana-enterprise:11.1.0",
             ports={
                 "dashboards": PortSpec(
                     number=3000,

--- a/main.star
+++ b/main.star
@@ -55,7 +55,7 @@ def run(
     plan.add_service(
         name=name,
         config=ServiceConfig(
-            image=f"grafana/grafana-enterprise:{grafana_version}",
+            image="grafana/grafana-enterprise:" + grafana_version,
             ports={
                 "dashboards": PortSpec(
                     number=3000,

--- a/main.star
+++ b/main.star
@@ -52,7 +52,7 @@ def run(
     plan.add_service(
         name=name,
         config=ServiceConfig(
-            image="grafana/grafana-enterprise:9.5.12",
+            image="grafana/grafana",
             ports={
                 "dashboards": PortSpec(
                     number=3000,

--- a/main.star
+++ b/main.star
@@ -8,7 +8,8 @@ def run(
     grafana_dashboards_location,
     name="grafana",
     grafana_dashboards_name="Grafana Dashboards in Kurtosis",
-    grafana_alerts_file="",
+    grafana_alerts_template="",
+    grafana_alerts_data={},
 ):
     """Runs provided Grafana dashboards in Kurtosis.
 
@@ -38,8 +39,8 @@ def run(
                 },
             ),
             "alerting/alerts.yml": struct(
-                template=read_file(grafana_alerts_file),
-                data={}
+                template=read_file(grafana_alerts_template),
+                data=grafana_alerts_data,
             ),
         }
     )

--- a/main.star
+++ b/main.star
@@ -6,7 +6,7 @@ def run(plan,
         grafana_dashboards_location, 
         name="grafana",
         grafana_dashboards_name="Grafana Dashboards in Kurtosis",
-        grafana_alerts_file,
+        grafana_alerts_file=None,
         ):
         """Runs provided Grafana dashboards in Kurtosis.
 

--- a/main.star
+++ b/main.star
@@ -38,8 +38,8 @@ def run(
                 },
             ),
             "alerting/alerts.yml": struct(
-                template=grafana_alerts_file,
-                data={},
+                template=read_file(grafana_alerts_file),
+                data={}
             ),
         }
     )

--- a/main.star
+++ b/main.star
@@ -8,7 +8,7 @@ def run(
     grafana_dashboards_location,
     name="grafana",
     grafana_dashboards_name="Grafana Dashboards in Kurtosis",
-    grafana_alerts_file=None,
+    grafana_alerts_file="",
 ):
     """Runs provided Grafana dashboards in Kurtosis.
 

--- a/main.star
+++ b/main.star
@@ -1,45 +1,56 @@
-CONFIG_DIR_PATH="/config"
-DASHBOARDS_DIR_PATH="/dashboards"
+CONFIG_DIR_PATH = "/config"
+DASHBOARDS_DIR_PATH = "/dashboards"
 
-def run(plan, 
-        prometheus_url, 
-        grafana_dashboards_location, 
-        name="grafana",
-        grafana_dashboards_name="Grafana Dashboards in Kurtosis",
-        grafana_alerts_file=None,
-        ):
-        """Runs provided Grafana dashboards in Kurtosis.
 
-        Args:
-            prometheus_url(string): Prometheus endpoint that will populate Grafana dashboard data.
-            grafana_dashboards_location(string): Where to find config for Grafana dashboard(s) (usually sitting somewhere repo of that's importing this package))
-            grafana_dashboards_name(string): Name of Grafana Dashboard provider.
-        """
+def run(
+    plan,
+    prometheus_url,
+    grafana_dashboards_location,
+    name="grafana",
+    grafana_dashboards_name="Grafana Dashboards in Kurtosis",
+    grafana_alerts_file=None,
+):
+    """Runs provided Grafana dashboards in Kurtosis.
 
-        # create config files artifacts based on datasource and dashboard providers info
-        datasource_config_template = read_file(src="./static-files/datasource.yml.tmpl")
-        dashboard_provider_config_template = read_file(src="./static-files/dashboard-providers.yml.tmpl")
-        grafana_config_files_artifact = plan.render_templates(
-            config={
-                "datasources/datasource.yml":struct(
-                    template=datasource_config_template,
-                    data={ "PrometheusURL": prometheus_url }
-                ),
-                "dashboards/dashboard-providers.yml":struct(
-                    template=dashboard_provider_config_template,
-                    data={
-                        "DashboardProviderName": grafana_dashboards_name,
-                        "DashboardsDirpath": DASHBOARDS_DIR_PATH,
-                    }
-                ),
-                "alerting/alerts.yml": grafana_alerts_file,
-            }
-        )
+    Args:
+        prometheus_url(string): Prometheus endpoint that will populate Grafana dashboard data.
+        grafana_dashboards_location(string): Where to find config for Grafana dashboard(s) (usually sitting somewhere repo of that's importing this package))
+        grafana_dashboards_name(string): Name of Grafana Dashboard provider.
+    """
 
-        # grab grafana dashboards from given location and upload them into enclave as a files artifact
-        grafana_dashboards_files_artifact = plan.upload_files(src=grafana_dashboards_location, name="grafana-dashboards")
+    # create config files artifacts based on datasource and dashboard providers info
+    datasource_config_template = read_file(src="./static-files/datasource.yml.tmpl")
+    dashboard_provider_config_template = read_file(
+        src="./static-files/dashboard-providers.yml.tmpl"
+    )
+    grafana_config_files_artifact = plan.render_templates(
+        config={
+            "datasources/datasource.yml": struct(
+                template=datasource_config_template,
+                data={"PrometheusURL": prometheus_url},
+            ),
+            "dashboards/dashboard-providers.yml": struct(
+                template=dashboard_provider_config_template,
+                data={
+                    "DashboardProviderName": grafana_dashboards_name,
+                    "DashboardsDirpath": DASHBOARDS_DIR_PATH,
+                },
+            ),
+            "alerting/alerts.yml": struct(
+                template=grafana_alerts_file,
+                data={},
+            ),
+        }
+    )
 
-        plan.add_service(name=name, config=ServiceConfig(
+    # grab grafana dashboards from given location and upload them into enclave as a files artifact
+    grafana_dashboards_files_artifact = plan.upload_files(
+        src=grafana_dashboards_location, name="grafana-dashboards"
+    )
+
+    plan.add_service(
+        name=name,
+        config=ServiceConfig(
             image="grafana/grafana-enterprise:9.5.12",
             ports={
                 "dashboards": PortSpec(
@@ -57,5 +68,6 @@ def run(plan,
             files={
                 CONFIG_DIR_PATH: grafana_config_files_artifact,
                 DASHBOARDS_DIR_PATH: grafana_dashboards_files_artifact,
-            }
-        ))
+            },
+        ),
+    )

--- a/main.star
+++ b/main.star
@@ -8,6 +8,7 @@ def run(
     grafana_dashboards_location,
     name="grafana",
     grafana_dashboards_name="Grafana Dashboards in Kurtosis",
+    grafana_version="9.5.12",
     grafana_alerting_template="",
     grafana_alerting_data={},
 ):
@@ -54,7 +55,7 @@ def run(
     plan.add_service(
         name=name,
         config=ServiceConfig(
-            image="grafana/grafana-enterprise:11.1.0",
+            image=f"grafana/grafana-enterprise:{grafana_version}",
             ports={
                 "dashboards": PortSpec(
                     number=3000,

--- a/main.star
+++ b/main.star
@@ -18,8 +18,9 @@ def run(
         prometheus_url (string): Prometheus endpoint that will populate Grafana dashboard data.
         grafana_dashboards_location (string): Where to find config for Grafana dashboard(s) (usually sitting somewhere in the repo that's importing this package).
         grafana_dashboards_name (string): Name of Grafana Dashboard provider.
-        grafana_alerting_template (string, optional): Path to the Grafana alerting file (usually sitting somewhere in the repo that's importing this package).
-        grafana_alerting_data (dict[string, string], optional): The data used when templating the grafana_alerting_template.
+        grafana_version (string, optional): The version of grafana to use.
+        grafana_alerting_template (string, optional): Path to the Grafana alerting template file (usually sitting somewhere in the repo that's importing this package).
+        grafana_alerting_data (dict[string, string], optional): The data used for templating the grafana_alerting_template.
     """
 
     # create config files artifacts based on datasource and dashboard providers info

--- a/main.star
+++ b/main.star
@@ -5,7 +5,9 @@ def run(plan,
         prometheus_url, 
         grafana_dashboards_location, 
         name="grafana",
-        grafana_dashboards_name="Grafana Dashboards in Kurtosis"):
+        grafana_dashboards_name="Grafana Dashboards in Kurtosis",
+        grafana_alerts_file,
+        ):
         """Runs provided Grafana dashboards in Kurtosis.
 
         Args:
@@ -30,6 +32,7 @@ def run(plan,
                         "DashboardsDirpath": DASHBOARDS_DIR_PATH,
                     }
                 ),
+                "alerting/alerts.yml": grafana_alerts_file,
             }
         )
 


### PR DESCRIPTION
- This PR allows users to specify an `alerts.yaml` that will be loaded in as predefined alerts in the grafana instance.
- Runs `kurtosis lint . --format`

@tedim52