### PR TITLE
feat: dashboards files artifact

### DIFF
--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,3 +1,3 @@
 name: "github.com/kurtosis-tech/grafana-package"
 replace:
-  github.com/kurtosis-tech/grafana-package: github.com/minhd-vu/grafana-package@file-artifact
+  github.com/kurtosis-tech/grafana-package: github.com/minhd-vu/grafana-package@dashboards-files-artifact

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,1 +1,2 @@
 name: "github.com/kurtosis-tech/grafana-package"
+

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,1 +1,3 @@
 name: "github.com/kurtosis-tech/grafana-package"
+replace:
+  github.com/kurtosis-tech/grafana-package: github.com/minhd-vu/grafana-package@file-artifact

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,2 +1,3 @@
 name: "github.com/kurtosis-tech/grafana-package"
-
+replace:
+  github.com/kurtosis-tech/grafana-package: github.com/minhd-vu/grafana-package@file-artifact

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,3 +1,1 @@
-name: "github.com/minhd-vu/grafana-package"
-replace:
-  github.com/kurtosis-tech/grafana-package: github.com/minhd-vu/grafana-package@dashboards-files-artifact
+name: "github.com/kurtosis-tech/grafana-package"

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,3 +1,1 @@
-name: "github.com/minhd-vu/grafana-package"
-replace:
-  github.com/kurtosis-tech/grafana-package: github.com/minhd-vu/grafana-package@file-artifact
+name: "github.com/kurtosis-tech/grafana-package"

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,3 +1,3 @@
-name: "github.com/kurtosis-tech/grafana-package"
+name: "github.com/minhd-vu/grafana-package"
 replace:
   github.com/kurtosis-tech/grafana-package: github.com/minhd-vu/grafana-package@file-artifact

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,3 +1,3 @@
-name: "github.com/kurtosis-tech/grafana-package"
+name: "github.com/minhd-vu/grafana-package"
 replace:
   github.com/kurtosis-tech/grafana-package: github.com/minhd-vu/grafana-package@dashboards-files-artifact

--- a/main.star
+++ b/main.star
@@ -11,8 +11,8 @@ def run(
     grafana_version="9.5.12",
     grafana_alerting_template="",
     grafana_alerting_data={},
-    grafana_dashboards_files_artifact=None,
     postgres_databases=[],
+    grafana_dashboards_files_artifact=None,
 ):
     """Runs provided Grafana dashboards in Kurtosis.
 

--- a/main.star
+++ b/main.star
@@ -49,7 +49,7 @@ def run(
         }
     )
 
-    if grafana_dashboards_files_artifact == None && grafana_dashboards_location != "":
+    if grafana_dashboards_files_artifact == None and grafana_dashboards_location != "":
         # grab grafana dashboards from given location and upload them into enclave as a files artifact
         grafana_dashboards_files_artifact = plan.upload_files(
             src=grafana_dashboards_location, name="grafana-dashboards"

--- a/main.star
+++ b/main.star
@@ -5,12 +5,13 @@ DASHBOARDS_DIR_PATH = "/dashboards"
 def run(
     plan,
     prometheus_url,
-    grafana_dashboards_location,
+    grafana_dashboards_location="",
     name="grafana",
     grafana_dashboards_name="Grafana Dashboards in Kurtosis",
     grafana_version="9.5.12",
     grafana_alerting_template="",
     grafana_alerting_data={},
+    grafana_dashboards_files_artifact=None,
 ):
     """Runs provided Grafana dashboards in Kurtosis.
 
@@ -48,10 +49,11 @@ def run(
         }
     )
 
-    # grab grafana dashboards from given location and upload them into enclave as a files artifact
-    grafana_dashboards_files_artifact = plan.upload_files(
-        src=grafana_dashboards_location, name="grafana-dashboards"
-    )
+    if grafana_dashboards_files_artifact == None:
+        # grab grafana dashboards from given location and upload them into enclave as a files artifact
+        grafana_dashboards_files_artifact = plan.upload_files(
+            src=grafana_dashboards_location, name="grafana-dashboards"
+        )
 
     plan.add_service(
         name=name,

--- a/main.star
+++ b/main.star
@@ -18,12 +18,13 @@ def run(
 
     Args:
         prometheus_url (string): Prometheus endpoint that will populate Grafana dashboard data.
-        grafana_dashboards_location (string): Where to find config for Grafana dashboard(s) (usually sitting somewhere in the repo that's importing this package).
-        grafana_dashboards_name (string): Name of Grafana Dashboard provider.
+        grafana_dashboards_location (string, optional): Where to find config for Grafana dashboard(s) (usually sitting somewhere in the repo that's importing this package). Setting this will override grafana_dashboards_files_artifact.
+        grafana_dashboards_name (string, optional): Name of Grafana Dashboard provider.
         grafana_version (string, optional): The version of grafana to use.
         grafana_alerting_template (string, optional): Path to the Grafana alerting template file (usually sitting somewhere in the repo that's importing this package).
         grafana_alerting_data (dict[string, string], optional): The data used for templating the grafana_alerting_template.
         postgres_databases (list[dict[string, string]], optional): The data used for templating the Postgres Grafana data source(s).
+        grafana_dashboards_files_artifact (string, optional): The dashboards files artifact, this will be overridden by grafana_dashboards_location if it's set.
     """
 
     # create config files artifacts based on datasource and dashboard providers info
@@ -59,7 +60,7 @@ def run(
         config=grafana_render_templates_config,
     )
 
-    if grafana_dashboards_files_artifact == None and grafana_dashboards_location != "":
+    if grafana_dashboards_location != "":
         # grab grafana dashboards from given location and upload them into enclave as a files artifact
         grafana_dashboards_files_artifact = plan.upload_files(
             src=grafana_dashboards_location, name="grafana-dashboards"

--- a/main.star
+++ b/main.star
@@ -49,7 +49,7 @@ def run(
         }
     )
 
-    if grafana_dashboards_files_artifact == None:
+    if grafana_dashboards_files_artifact == None && grafana_dashboards_location != "":
         # grab grafana dashboards from given location and upload them into enclave as a files artifact
         grafana_dashboards_files_artifact = plan.upload_files(
             src=grafana_dashboards_location, name="grafana-dashboards"

--- a/main.star
+++ b/main.star
@@ -66,6 +66,13 @@ def run(
             src=grafana_dashboards_location, name="grafana-dashboards"
         )
 
+    files = {
+        CONFIG_DIR_PATH: grafana_dashboards_files_artifact
+    }
+
+    if grafana_dashboards_files_artifact != "":
+        files[DASHBOARDS_DIR_PATH] = grafana_dashboards_files_artifact
+
     plan.add_service(
         name=name,
         config=ServiceConfig(
@@ -83,9 +90,6 @@ def run(
                 "GF_AUTH_ANONYMOUS_ORG_ROLE": "Admin",
                 "GF_AUTH_ANONYMOUS_ORG_NAME": "Main Org.",
             },
-            files={
-                CONFIG_DIR_PATH: grafana_config_files_artifact,
-                DASHBOARDS_DIR_PATH: grafana_dashboards_files_artifact,
-            },
+            files=files,
         ),
     )

--- a/main.star
+++ b/main.star
@@ -67,7 +67,7 @@ def run(
         )
 
     files = {
-        CONFIG_DIR_PATH: grafana_dashboards_files_artifact
+        CONFIG_DIR_PATH: grafana_config_files_artifact
     }
 
     if grafana_dashboards_files_artifact != "":

--- a/main.star
+++ b/main.star
@@ -12,7 +12,7 @@ def run(
     grafana_alerting_template="",
     grafana_alerting_data={},
     postgres_databases=[],
-    grafana_dashboards_files_artifact=None,
+    grafana_dashboards_files_artifact="",
 ):
     """Runs provided Grafana dashboards in Kurtosis.
 


### PR DESCRIPTION
When setting `grafana_dashboards_location` from a private repo, it requires you to have to do a `kurtosis login`. Sometimes this is not possible when the repo is part of an organization you don't have permissions for. Therefore, allow passing a files artifact.

This also makes it optional to pass a dashboards directory. Sometimes you want to run grafana without predefined dashboards.